### PR TITLE
Update control-1.1.rst - correct typo in calculation of completeness score

### DIFF
--- a/control-1/control-1.1.rst
+++ b/control-1/control-1.1.rst
@@ -69,7 +69,7 @@ Completeness Score
 	* - **Metric**
 	  - | What percentage of the current enterprise asset inventory contains necessary detailed information?
 	* - **Calculation**
-	  - :code:`M8 / M1`
+	  - :code:`M7 / M1`
 
 Procedural Review
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Corrected typo in the calculation of 'Completeness Score' to use M7 (count of assets missing detailed information) rather than M8 (months since inventory update)