### PR TITLE
Update control-1.1.rst Completeness score calculation change

### DIFF
--- a/control-1/control-1.1.rst
+++ b/control-1/control-1.1.rst
@@ -69,7 +69,7 @@ Completeness Score
 	* - **Metric**
 	  - | What percentage of the current enterprise asset inventory contains necessary detailed information?
 	* - **Calculation**
-	  - :code:`M8 / M1`
+	  - :code:`M6 / M1`
 
 Procedural Review
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I am reading the Completeness Score metric "What percentage of the current enterprise asset inventory contains necessary detailed information?" The calculation stated "M8/M1." I don't think this calculation makes sense as M8 is the months since las update to GV1. Instead, I would like to propose changing it to M6/M1. In this case we would get count of items with all necessary detail over GV1. Please let me know if I misunderstood the documentation.